### PR TITLE
Add WP-CLI SSH to package-index

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5,3 +5,4 @@ https://github.com/pixline/wp-cli-theme-test-command
 https://github.com/srtfisher/wp-composer
 https://github.com/oxford-themes/wp-cli-git-command
 https://github.com/pods-framework/pods-wp-cli
+https://github.com/x-team/wp-cli-ssh


### PR DESCRIPTION
We had to admittedly do some hackery to make the idea work. Perhaps WP-CLI needs some earlier hooks to more elegantly make possible what we've done here with hacking the use of the `require` config, but it is working very well. Feedback appreciated!
