### PR TITLE
Updated repo URL for wp-cli-git-command

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3,6 +3,6 @@ https://github.com/danielbachhuber/wp-cli-stat-command
 https://github.com/humanmade/wp-remote-cli
 https://github.com/pixline/wp-cli-theme-test-command
 https://github.com/srtfisher/wp-composer
-https://github.com/oxford-themes/wp-cli-git-command
+https://github.com/mattes/wp-cli-git-command
 https://github.com/pods-framework/pods-wp-cli
 https://github.com/x-team/wp-cli-ssh


### PR DESCRIPTION
https://github.com/mattes/wp-cli-git-command
