### PR TITLE
Add `wp plugins-api` command

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -24,3 +24,4 @@ https://github.com/sinebridge/wp-cli-about
 https://github.com/viewone/wp-cli-environment
 https://github.com/sebastiaandegeus/wp-cli-salts-command
 https://github.com/szepeviktor/wp-cli-database-prefix-command
+https://github.com/miya0001/wp-plugins-api


### PR DESCRIPTION
WP-CLI command for getting plugin information form WordPress.org Plugin API.
- `wp plugins-api author <author>` - Get a list of plugins for specific author.
- `wp plugins-api browse <browse>` - Get a list of plugins for popular/new/updated/top-rated.
- `wp plugins-api info <slug>` - Get a plugin information specific plugin.
