### PR TITLE
Add wp-maintenance-mode command

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -26,3 +26,4 @@ https://github.com/sebastiaandegeus/wp-cli-salts-command
 https://github.com/szepeviktor/wp-cli-database-prefix-command
 https://github.com/miya0001/wp-plugins-api
 https://github.com/tillkruss/wp-cli-kraken
+https://github.com/dpiquet/wp-maintenance-mode-cli


### PR DESCRIPTION
wp-maintenance-mode command is a cli interface to wp-maintenance-mode wordpress plugin