### PR TITLE
Add a `wp site duplicate` command to multisite networks

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -27,3 +27,4 @@ https://github.com/szepeviktor/wp-cli-database-prefix-command
 https://github.com/miya0001/wp-plugins-api
 https://github.com/tillkruss/wp-cli-kraken
 https://github.com/dpiquet/wp-maintenance-mode-cli
+https://github.com/pierre-dargham/wp-cli-multisite-clone-duplicator


### PR DESCRIPTION
Add a `wp site duplicate` command to multisite networks. Using https://github.com/pierre-dargham/multisite-clone-duplicator libraries.

Clones an existing site into a new one in a multisite installation : copies all the posts, settings and files.

Note :needs wp-cli core https://github.com/wp-cli/wp-cli/issues/1795 bugfix to run properly.