### PR TITLE
Add wp-cli-lint

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -28,3 +28,4 @@ https://github.com/miya0001/wp-plugins-api
 https://github.com/tillkruss/wp-cli-kraken
 https://github.com/dpiquet/wp-maintenance-mode-cli
 https://github.com/pierre-dargham/wp-cli-multisite-clone-duplicator
+https://github.com/frozzare/wp-cli-lint


### PR DESCRIPTION
`wp-cli-lint` is a command for running `phpcs` but through `wp-cli`. It looks for the closest ruleset xml or in `wp-cli` config for `lint` settings or `--standard`

Example:

```
wp lint path/to/code
wp lint path/to/code --standard=WordPress-Extra
```