### PR TITLE
Add wp-cli-media-restore

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -40,3 +40,4 @@ https://github.com/wp-cli/scaffold-package
 https://github.com/wp-cli/server-command
 https://github.com/wp-cli/wp-super-cache-cli
 https://github.com/x-team/wp-cli-ssh
+https://github.com/frozzare/wp-cli-media-restore


### PR DESCRIPTION
Media restore command based on another older command with support for custom upload directories, e.g bedrock.