### PR TITLE
Adding MU-Migration

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/10up/MU-Migration
 https://github.com/10up/wp-hammer
 https://github.com/aaemnnosttv/wp-cli-dotenv-command
 https://github.com/aaemnnosttv/wp-cli-http-command


### PR DESCRIPTION
This WP-CLI package makes the process of moving sites from single WordPress sites to a Multisite instance much easier. It exports everything into a zip package which can be used to automatically import it within the desired Multisite installation.