### PR TITLE
Add wp-cli-tgmpa-plugin

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -19,6 +19,7 @@ https://github.com/frozzare/wp-cli-lint
 https://github.com/frozzare/wp-cli-media-restore
 https://github.com/GeekPress/wp-rocket-cli
 https://github.com/humanmade/wp-remote-cli
+https://github.com/itspriddle/wp-cli-tgmpa-plugin
 https://github.com/mattclegg/wp-cli_check-content
 https://github.com/mattes/wp-cli-git-command
 https://github.com/mattes/wp-cli-quick-command


### PR DESCRIPTION
This WP-CLI package provides the `wp tgmpa-plugin` command for working with plugins required using the [TGM Plugin Activation](http://tgmpluginactivation.com/) library.