### PR TITLE
added wp plugin install-missing

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6,6 +6,7 @@ https://github.com/aaemnnosttv/wp-cli-valet-command
 https://github.com/adrigen/wp-cli-piwik
 https://github.com/alleyinteractive/wp-doc-command
 https://github.com/astorm/wp-static-html-output-plugin
+https://github.com/billerickson/wp-cli-plugin-install-missing
 https://github.com/boonebgorges/wp-cli-buddypress
 https://github.com/boonebgorges/wp-cli-git-helper
 https://github.com/c10b10/wp-cli-deploy


### PR DESCRIPTION
This command installs any plugins that are active but missing.