### PR TITLE
Add iandunn/wp-cli-plugin-active-on-sites

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -23,6 +23,7 @@ https://github.com/frozzare/wp-cli-media-restore
 https://github.com/GeekPress/wp-rocket-cli
 https://github.com/humanmade/wp-remote-cli
 https://github.com/iandunn/wp-cli-rename-db-prefix
+https://github.com/iandunn/wp-cli-plugin-active-on-sites
 https://github.com/itspriddle/wp-cli-tgmpa-plugin
 https://github.com/JayWood/jw-wpcli-random-posts
 https://github.com/mattclegg/wp-cli_check-content


### PR DESCRIPTION
`wp plugin active-on-sites <plugin_slug>` lists all sites in a Multisite network that have activated the given plugin.