### PR TITLE
Add BeAPI/wp-cli-light-db-export

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6,6 +6,7 @@ https://github.com/aaemnnosttv/wp-cli-valet-command
 https://github.com/adrigen/wp-cli-piwik
 https://github.com/alleyinteractive/wp-doc-command
 https://github.com/astorm/wp-static-html-output-plugin
+https://github.com/BeAPI/wp-cli-light-db-export
 https://github.com/billerickson/wp-cli-plugin-install-missing
 https://github.com/boonebgorges/wp-cli-buddypress
 https://github.com/boonebgorges/wp-cli-git-helper


### PR DESCRIPTION
Export full database with tables and allows to ignore data from some, like log tables.