### PR TITLE
Add pressbooks/pb-cli to package index.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -44,6 +44,7 @@ https://github.com/pixline/wp-cli-php-devtools
 https://github.com/pixline/wp-cli-proxy
 https://github.com/pixline/wp-cli-theme-test-command
 https://github.com/pods-framework/pods-wp-cli
+https://github.com/pressbooks/pb-cli
 https://github.com/Redkiwi-NL/local-config
 https://github.com/runcommand/db-ack
 https://github.com/runcommand/dist-archive


### PR DESCRIPTION
Add some commands for managing a [Pressbooks](https://pressbooks.com) network to wp-cli (so far just `wp scaffold book-theme`).