### PR TITLE
Update repositories.txt adding db2utf8 command

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -75,6 +75,7 @@ https://github.com/trepmal/blog-extractor
 https://github.com/trepmal/wp-revisions-cli
 https://github.com/vccw-team/wp-cli-scaffold-movefile
 https://github.com/viewone/wp-cli-environment
+https://github.com/welaika/wp-cli-db2utf8
 https://github.com/wp-cli/scaffold-package
 https://github.com/wp-cli/server-command
 https://github.com/wp-cli/wp-super-cache-cli


### PR DESCRIPTION
This was an internal tool used to convert tables in UTF8-mb4 to UTF8 on newly bootstrapped development installation. Useful if you have a remote stage which does not support UTF8-mb4.

Unfortunately we did not found a comfortable way to install directly from a private repository, so we have refactored it a bit and we are going to make it public and thus easily installable.