### PR TITLE
Add wp-installer to the index

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -83,3 +83,4 @@ https://github.com/wp-cli/server-command
 https://github.com/wp-cli/wp-super-cache-cli
 https://github.com/x-team/wp-cli-ssh
 https://github.com/anhskohbo/wp-cli-themecheck
+https://github.com/mattgrshaw/wp-installer


### PR DESCRIPTION
This helps to speed up some development tasks using WP CLI commands that can accept config from the `~/.wp-cli/config.yaml` file.

Repo here - https://github.com/mattgrshaw/wp-installer