### PR TITLE
Add the `wpcli-wpbrowser-tests` package to list.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -34,6 +34,7 @@ https://github.com/iandunn/wp-cli-rename-db-prefix
 https://github.com/iandunn/wp-cli-plugin-active-on-sites
 https://github.com/itspriddle/wp-cli-tgmpa-plugin
 https://github.com/JayWood/jw-wpcli-random-posts
+https://github.com/lucatume/wpcli-wpbrowser-tests
 https://github.com/markri/wp-sec
 https://github.com/mattclegg/wp-cli_check-content
 https://github.com/mattes/wp-cli-git-command


### PR DESCRIPTION
Scaffold wp-browser based tests for themes and plugins.
I think the package has all that's needed; let me know if something is missing.