### PR TITLE
Added wp-cli-letsencrypt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -32,6 +32,7 @@ https://github.com/getshifter/wp-cli-shifter
 https://github.com/humanmade/wp-remote-cli
 https://github.com/iandunn/wp-cli-rename-db-prefix
 https://github.com/iandunn/wp-cli-plugin-active-on-sites
+https://github.com/ircf/wp-cli-letsencrypt
 https://github.com/itspriddle/wp-cli-tgmpa-plugin
 https://github.com/JayWood/jw-wpcli-random-posts
 https://github.com/lucatume/wpcli-wpbrowser-tests


### PR DESCRIPTION
Provides a letsencrypt command to create a SAN SSL certificate for a WordPress network using Let's Encrypt.