### PR TITLE
Add Update Check to the package index

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -29,6 +29,7 @@ https://github.com/frozzare/wp-cli-lint
 https://github.com/frozzare/wp-cli-media-restore
 https://github.com/GeekPress/wp-rocket-cli
 https://github.com/getshifter/wp-cli-shifter
+https://github.com/growella/update-check
 https://github.com/humanmade/wp-remote-cli
 https://github.com/iandunn/wp-cli-rename-db-prefix
 https://github.com/iandunn/wp-cli-plugin-active-on-sites


### PR DESCRIPTION
Adds [the `wp update-check` package](https://github.com/growella/update-check), to automatically check for available core, plugin, or theme updates.