### PR TITLE
Add WP Engine wp-cli access

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -63,6 +63,7 @@ https://github.com/runcommand/media-sideload
 https://github.com/runcommand/media-sizes
 https://github.com/runcommand/query-debug
 https://github.com/runcommand/reset-passwords
+https://github.com/ryanshoover/wpe-cli
 https://github.com/sebastiaandegeus/wp-cli-salts-command
 https://github.com/sinebridge/wp-cli-about
 https://github.com/rxnlabs/wp-composer


### PR DESCRIPTION
Add ryanshoover/wpe-cli package, an unofficial project to provide local wp-cli commands to WP Engine installs. 

wpe-cli provides wp-cli, site backup, and cache clear functions.