### PR TITLE
Add deprecation notice with link to blog post.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-WP-CLI Package Index
-====================
+WP-CLI Package Index (deprecated)
+================================
 
-The code and configuration in this repository builds the [Package Index](http://wp-cli.org/package-index). It's rebuilt on a 10 minute cron.
-
-Want to submit your own package for consideration? First, [follow the instructions](http://wp-cli.org/docs/commands-cookbook/#add-to-the-package-index) on preparing your package for submission. 
-
-Once you think it's ready, you can submit your package by editing [repositories.txt](repositories.txt) and submitting a pull request. Please add your package in alphabetical order.
+> **NOTE:** The WP-CLI Package Index is being **deprecated**.
+>
+> Refer to [this blog post](https://make.wordpress.org/cli/2017/07/18/feature-development-discussion-recap/) to read about the reasoning behind this change.


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/4236