### PR TITLE
Add prune-packages script

### DIFF
--- a/scripts/prune-packages.php
+++ b/scripts/prune-packages.php
@@ -1,0 +1,41 @@
+<?php
+
+$wp_cli_packages = file(
+	dirname( __DIR__ ) . '/repositories.txt',
+	FILE_IGNORE_NEW_LINES
+);
+
+// Filter out lines for packages that are available on packagist.org
+
+$wp_cli_only = array_filter(
+	$wp_cli_packages,
+	function ( $repo_url ) {
+		$package_name = str_replace( 'https://github.com/', '', $repo_url );
+		$packagist_res = json_decode(
+			file_get_contents( "https://packagist.org/search.json?q={$package_name}" )
+		);
+
+		if ( ! $packagist_res ) {
+			throw new Exception( "Invalid package search results for $package_name" );
+		}
+
+		// If no results, the package wasn't found on packagist!
+		if ( ! $packagist_res->total ) {
+			return true;
+		}
+
+		// Iterate over the results to ensure an exact match since search results return fuzzy matches.
+		foreach ( $packagist_res->results as $p ) {
+			if ( $p->name === $package_name ) {
+				return false;
+			}
+		}
+
+		// If we got this far, there were results but none that matched the specific package we were looking for.
+		return true;
+	}
+);
+
+// Output the filtered list of repositories
+// which now only include packages that are on the wp-cli package index.
+echo join( "\n", $wp_cli_only ) . "\n";


### PR DESCRIPTION
This has been slightly modified from the version originally used for https://github.com/wp-cli/package-index/pull/121, but mostly formatting. The main difference is that the list of repositories is sourced from the local `repositories.txt` rather than fetching the file contents from GitHub.

This script outputs a filtered version of the `repositories.txt` file to exclude lines that reference packages that exist by the same name on packagist.org.

### Usage

Dry run

```sh
$ php scripts/prune-packages.php
```

<details>
<summary>Example</summary>

```
⚡  php scripts/prune-packages.php 
https://github.com/10up/MU-Migration
https://github.com/10up/wp-hammer
https://github.com/alessandrotesoro/wp-cli-helpscout-docs-parser
https://github.com/alessandrotesoro/wp-usergen-cli
https://github.com/alleyinteractive/wp-doc-command
https://github.com/astorm/wp-static-html-output-plugin
https://github.com/BeAPI/wp-cli-light-db-export
https://github.com/billerickson/wp-cli-plugin-install-missing
https://github.com/binarygary/db-checkpoint
https://github.com/brightoak/wp-cli-envoyer
https://github.com/boonebgorges/wp-cli-buddypress
https://github.com/boonebgorges/wp-cli-git-helper
https://github.com/c10b10/wp-cli-deploy
https://github.com/danielbachhuber/wp-cli-pre-cache-command
https://github.com/danielbachhuber/wp-rest-cli
https://github.com/ernilambar/database-command
https://github.com/GeekPress/wp-rocket-cli
https://github.com/getshifter/wp-cli-shifter
https://github.com/iandunn/wp-cli-rename-db-prefix
https://github.com/iandunn/wp-cli-plugin-active-on-sites
https://github.com/itspriddle/wp-cli-tgmpa-plugin
https://github.com/JayWood/jw-wpcli-random-posts
https://github.com/lucatume/wpcli-wpbrowser-tests
https://github.com/mattclegg/wp-cli_check-content
https://github.com/mattes/wp-cli-git-command
https://github.com/mattes/wp-cli-quick-command
https://github.com/michaloo/wp-cli-environmentalize
https://github.com/mikedance/wp-cli-favorite-plugins
https://github.com/miya0001/wp-cli-vhosts
https://github.com/miya0001/wp-plugins-api
https://github.com/Nikschavan/revslider-search-replace
https://github.com/ocean90/wp-cli-flush-cache
https://github.com/pantheon-systems/wp_launch_check
https://github.com/petenelson/wp-cli-size
https://github.com/pixline/wp-cli-proxy
https://github.com/Redkiwi-NL/local-config
https://github.com/runcommand/assign-featured-images
https://github.com/runcommand/db-ack
https://github.com/runcommand/find-unused-themes
https://github.com/runcommand/hook
https://github.com/runcommand/manifest
https://github.com/runcommand/media-sideload
https://github.com/runcommand/media-sizes
https://github.com/runcommand/query-debug
https://github.com/runcommand/reset-passwords
https://github.com/sebastiaandegeus/wp-cli-salts-command
https://github.com/sinebridge/wp-cli-about
https://github.com/rxnlabs/wp-composer
https://github.com/oderland/wp-cli-oderland
https://github.com/stianlik/wp-cli-mig
https://github.com/szepeviktor/wp-cli-database-prefix-command
https://github.com/tillkruss/wp-cli-kraken
https://github.com/timhysniu/wp-cli-template
https://github.com/timhysniu/wp-dbdelta
https://github.com/trepmal/blog-extractor
https://github.com/vccw-team/scaffold-vccw
https://github.com/vccw-team/wp-cli-scaffold-movefile
https://github.com/viewone/wp-cli-environment
https://github.com/welaika/wp-cli-db2utf8
https://github.com/mattgrshaw/wp-installer
```

</details>

**Updating the file at the same time**

```sh
$ php scripts/prune-packages.php > repositories.txt
```